### PR TITLE
Increment Bindgen Version

### DIFF
--- a/xgboost-sys/Cargo.toml
+++ b/xgboost-sys/Cargo.toml
@@ -13,4 +13,4 @@ readme = "README.md"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.36"
+bindgen = "0.59"

--- a/xgboost-sys/build.rs
+++ b/xgboost-sys/build.rs
@@ -36,6 +36,7 @@ fn main() {
         .header("wrapper.h")
         .clang_arg(format!("-I{}", xgb_root.join("include").display()))
         .clang_arg(format!("-I{}", xgb_root.join("rabit/include").display()))
+        .size_t_is_usize(true)
         .generate()
         .expect("Unable to generate bindings.");
 


### PR DESCRIPTION
Hi guys. Any thoughts on incrementing bindgen version? Got into an issue where another library was using a newer version of bindgen, which link to a newer version of clang.