### PR TITLE
Update XGBoost 1.4.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,5 @@
 [submodule "xgboost-sys/xgboost"]
 	path = xgboost-sys/xgboost
-	url = git@github.com:davechallis/xgboost
+	url = https://github.com/davechallis/xgboost
 	branch = v0.80-modified
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,4 @@
 	path = xgboost-sys/xgboost
 	url = git@github.com:davechallis/xgboost
 	branch = v0.80-modified
+	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,5 +1,4 @@
 [submodule "xgboost-sys/xgboost"]
 	path = xgboost-sys/xgboost
 	url = https://github.com/davechallis/xgboost
-	branch = v0.80-modified
-	ignore = dirty
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "xgboost-sys/xgboost"]
 	path = xgboost-sys/xgboost
-	url = https://github.com/davechallis/xgboost
+	url = git@github.com:davechallis/xgboost
 	branch = v0.80-modified

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xgboost"
-version = "0.1.4"
+version = "0.2.0"
 authors = ["Dave Challis <dave@suicas.net>"]
 license = "MIT"
 repository = "https://github.com/davechallis/rust-xgboost"
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/xgboost"
 readme = "README.md"
 
 [dependencies]
-xgboost-sys = { path="./xgboost-sys" }
+xgboost-sys = "0.2.0"
 libc = "0.2"
 derive_builder = "0.5"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ documentation = "https://docs.rs/xgboost"
 readme = "README.md"
 
 [dependencies]
-xgboost-sys = "0.1.2"
+xgboost-sys = { path="./xgboost-sys" }
 libc = "0.2"
 derive_builder = "0.5"
 log = "0.4"

--- a/examples/basic/Cargo.toml
+++ b/examples/basic/Cargo.toml
@@ -6,6 +6,6 @@ publish = false
 
 [dependencies]
 xgboost = { path = "../../" }
-sprs = "0.6"
+sprs = "0.11"
 log = "0.4"
 env_logger = "0.5"

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -97,7 +97,7 @@ fn main() {
     let mut data = Vec::new();
 
     let reader = BufReader::new(File::open("../../xgboost-sys/xgboost/demo/data/agaricus.txt.train").unwrap());
-    let mut current_row = 0;
+    let mut current_row: u64 = 0;
     for line in reader.lines() {
         let line = line.unwrap();
         let sample: Vec<&str> = line.split_whitespace().collect();
@@ -106,7 +106,7 @@ fn main() {
         for entry in &sample[1..] {
             let pair: Vec<&str> = entry.split(':').collect();
             rows.push(current_row);
-            cols.push(pair[0].parse::<usize>().unwrap());
+            cols.push(pair[0].parse::<u64>().unwrap());
             data.push(pair[1].parse::<f32>().unwrap());
         }
 
@@ -114,8 +114,8 @@ fn main() {
     }
 
     // work out size of sparse matrix from max row/col values
-    let shape = (*rows.iter().max().unwrap() + 1 as usize,
-                 *cols.iter().max().unwrap() + 1 as usize);
+    let shape = ((*rows.iter().max().unwrap() + 1) as usize,
+                 (*cols.iter().max().unwrap() + 1) as usize);
     let triplet_mat = sprs::TriMatBase::from_triplets(shape, rows, cols, data);
     let csr_mat = triplet_mat.to_csr();
 

--- a/examples/multiclass_classification/Cargo.toml
+++ b/examples/multiclass_classification/Cargo.toml
@@ -8,4 +8,4 @@ publish = false
 xgboost = { path = "../../" }
 log = "0.4"
 env_logger = "0.5"
-reqwest = "0.8"
+reqwest = { version = "0.11", features = ["blocking"] }

--- a/examples/multiclass_classification/src/main.rs
+++ b/examples/multiclass_classification/src/main.rs
@@ -73,7 +73,7 @@ fn download_dataset<P: AsRef<Path>>(dst: P) {
     }
 
     debug!("Fetching training dataset from {}", url);
-    let mut response = reqwest::get(url).expect("failed to download training set data");
+    let mut response = reqwest::blocking::get(url).expect("failed to download training set data");
 
     let file = File::create(dst).expect(&format!("failed to create file {}", dst.display()));
     let mut writer = BufWriter::new(file);

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -178,7 +178,7 @@ impl Booster {
                     for (dmat, dmat_name) in eval_sets {
                         let margin = bst.predict_margin(dmat)?;
                         let eval_result = eval_fn(&margin, dmat);
-                        let mut eval_results = dmat_eval_results.entry(eval_name.to_string())
+                        let eval_results = dmat_eval_results.entry(eval_name.to_string())
                             .or_insert_with(IndexMap::new);
                         eval_results.insert(dmat_name.to_string(), eval_result);
                     }
@@ -188,7 +188,7 @@ impl Booster {
                 let mut eval_dmat_results = BTreeMap::new();
                 for (dmat_name, eval_results) in &dmat_eval_results {
                     for (eval_name, result) in eval_results {
-                        let mut dmat_results = eval_dmat_results.entry(eval_name).or_insert_with(BTreeMap::new);
+                        let dmat_results = eval_dmat_results.entry(eval_name).or_insert_with(BTreeMap::new);
                         dmat_results.insert(dmat_name, result);
                     }
                 }
@@ -548,7 +548,7 @@ impl Booster {
                     let score = metric_parts[1].parse::<f32>()
                         .unwrap_or_else(|_| panic!("Unable to parse XGBoost metrics output: {}", eval));
 
-                    let mut metric_map = result.entry(evname.to_string()).or_insert_with(IndexMap::new);
+                    let metric_map = result.entry(evname.to_string()).or_insert_with(IndexMap::new);
                     metric_map.insert(metric.to_owned(), score);
                 }
             }

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -627,7 +627,6 @@ impl FeatureMap {
             };
             features.0.insert(feature_num, (feature_name.to_string(), feature_type));
         }
-
         Ok(features)
     }
 }
@@ -708,7 +707,8 @@ mod tests {
 
     #[test]
     fn save_and_load_from_buffer() {
-        let mut booster = load_test_booster();
+        let dmat_train = DMatrix::load("xgboost-sys/xgboost/demo/data/agaricus.txt.train").unwrap();
+        let mut booster = Booster::new_with_cached_dmats(&BoosterParameters::default(), &[&dmat_train]).unwrap();
         let attr = booster.get_attribute("foo").expect("Getting attribute failed");
         assert_eq!(attr, None);
 
@@ -716,7 +716,7 @@ mod tests {
         let attr = booster.get_attribute("foo").expect("Getting attribute failed");
         assert_eq!(attr, Some("bar".to_owned()));
 
-        let mut dir = tempfile::tempdir().expect("create temp dir");
+        let dir = tempfile::tempdir().expect("create temp dir");
         let path = dir.path().join("test-xgboost-model");
         booster.save(&path).expect("saving booster");
         drop(booster);
@@ -943,6 +943,8 @@ mod tests {
     fn dump_model() {
         let dmat_train = DMatrix::load("xgboost-sys/xgboost/demo/data/agaricus.txt.train").unwrap();
 
+        println!("{:?}", dmat_train.shape());
+
         let tree_params = tree::TreeBoosterParametersBuilder::default()
             .max_depth(2)
             .eta(1.0)
@@ -967,75 +969,75 @@ mod tests {
             .expect("failed to parse feature map file");
 
         assert_eq!(booster.dump_model(true, Some(&features)).unwrap(),
-"0:[odor=pungent] yes=2,no=1,gain=4000.53101,cover=1628.25
-	1:[stalk-root=cup] yes=4,no=3,gain=1158.21204,cover=924.5
+"0:[odor=none] yes=2,no=1,gain=4000.53101,cover=1628.25
+1:[stalk-root=club] yes=4,no=3,gain=1158.21204,cover=924.5
 		3:leaf=1.71217716,cover=812
 		4:leaf=-1.70044053,cover=112.5
-	2:[spore-print-color=orange] yes=6,no=5,gain=198.173828,cover=703.75
+2:[spore-print-color=green] yes=6,no=5,gain=198.173828,cover=703.75
 		5:leaf=-1.94070864,cover=690.5
 		6:leaf=1.85964918,cover=13.25
 
-0:[stalk-root=missing] yes=2,no=1,gain=832.545044,cover=788.852051
-	1:[odor=pungent] yes=4,no=3,gain=569.725098,cover=768.389709
+0:[stalk-root=rooted] yes=2,no=1,gain=832.545044,cover=788.852051
+1:[odor=none] yes=4,no=3,gain=569.725098,cover=768.389709
 		3:leaf=0.78471756,cover=458.936859
 		4:leaf=-0.968530357,cover=309.45282
 	2:leaf=-6.23624468,cover=20.462389
 
-0:[ring-type=sheathing] yes=2,no=1,gain=368.744568,cover=457.069458
-	1:[stalk-surface-below-ring=silky] yes=4,no=3,gain=226.33696,cover=221.051468
+0:[ring-type=pendant] yes=2,no=1,gain=368.744568,cover=457.069458
+1:[stalk-surface-below-ring=scaly] yes=4,no=3,gain=226.33696,cover=221.051468
 		3:leaf=0.658725023,cover=212.999451
 		4:leaf=5.77228642,cover=8.05200672
-	2:[spore-print-color=white] yes=6,no=5,gain=258.184265,cover=236.018005
+2:[spore-print-color=purple] yes=6,no=5,gain=258.184265,cover=236.018005
 		5:leaf=-0.791407049,cover=233.487625
 		6:leaf=-9.421422,cover=2.53038669
 
-0:[odor=musty] yes=2,no=1,gain=140.486069,cover=364.119354
-	1:[gill-size=narrow] yes=4,no=3,gain=139.860504,cover=274.101959
+0:[odor=foul] yes=2,no=1,gain=140.486069,cover=364.119354
+1:[gill-size=broad] yes=4,no=3,gain=139.860504,cover=274.101959
 		3:leaf=0.614153326,cover=95.8599854
 		4:leaf=-0.877905607,cover=178.241974
 	2:leaf=1.07747853,cover=90.0174103
 
-0:[spore-print-color=orange] yes=2,no=1,gain=112.605011,cover=189.202194
-	1:[gill-spacing=crowded] yes=4,no=3,gain=66.4029999,cover=177.771835
+0:[spore-print-color=green] yes=2,no=1,gain=112.605011,cover=189.202194
+1:[gill-spacing=close] yes=4,no=3,gain=66.4029999,cover=177.771835
 		3:leaf=-1.26934469,cover=42.277401
 		4:leaf=0.152607277,cover=135.494431
 	2:leaf=2.92190909,cover=11.4303684
 
-0:[odor=anise] yes=2,no=1,gain=52.5610275,cover=170.612762
-	1:[odor=creosote] yes=4,no=3,gain=67.3869553,cover=150.881165
+0:[odor=almond] yes=2,no=1,gain=52.5610275,cover=170.612762
+1:[odor=anise] yes=4,no=3,gain=67.3869553,cover=150.881165
 		3:leaf=0.431742132,cover=131.902222
 		4:leaf=-1.53846073,cover=18.9789505
-	2:[gill-spacing=crowded] yes=6,no=5,gain=12.4420624,cover=19.731596
+2:[gill-spacing=close] yes=6,no=5,gain=12.4420624,cover=19.731596
 		5:leaf=-3.02413678,cover=3.65769386
 		6:leaf=-1.02315068,cover=16.0739021
 
-0:[odor=pungent] yes=2,no=1,gain=66.2389145,cover=142.360611
-	1:[odor=creosote] yes=4,no=3,gain=31.2294312,cover=72.7557373
+0:[odor=none] yes=2,no=1,gain=66.2389145,cover=142.360611
+1:[odor=anise] yes=4,no=3,gain=31.2294312,cover=72.7557373
 		3:leaf=0.777142286,cover=64.5309982
 		4:leaf=-1.19710124,cover=8.22473907
-	2:[spore-print-color=orange] yes=6,no=5,gain=12.1987419,cover=69.6048737
+2:[spore-print-color=green] yes=6,no=5,gain=12.1987419,cover=69.6048737
 		5:leaf=-0.912605286,cover=66.1211166
 		6:leaf=0.836115122,cover=3.48375821
 
-0:[gill-size=narrow] yes=2,no=1,gain=20.6531773,cover=79.4027634
-	1:[spore-print-color=yellow] yes=4,no=3,gain=16.0703697,cover=34.9289207
+0:[gill-size=broad] yes=2,no=1,gain=20.6531773,cover=79.4027634
+1:[spore-print-color=white] yes=4,no=3,gain=16.0703697,cover=34.9289207
 		3:leaf=-0.0180106498,cover=25.0319824
 		4:leaf=1.4361918,cover=9.89693928
-	2:[odor=musty] yes=6,no=5,gain=22.1144333,cover=44.4738464
+2:[odor=foul] yes=6,no=5,gain=22.1144333,cover=44.4738464
 		5:leaf=-0.908311546,cover=36.982872
 		6:leaf=0.890622675,cover=7.49097395
 
-0:[odor=anise] yes=2,no=1,gain=11.7128553,cover=53.3251991
-	1:[ring-type=sheathing] yes=4,no=3,gain=12.546154,cover=44.299942
+0:[odor=almond] yes=2,no=1,gain=11.7128553,cover=53.3251991
+1:[ring-type=pendant] yes=4,no=3,gain=12.546154,cover=44.299942
 		3:leaf=-0.515293062,cover=15.7899179
 		4:leaf=0.56883812,cover=28.5100231
 	2:leaf=-1.01502442,cover=9.02525806
 
-0:[population=numerous] yes=2,no=1,gain=14.8892794,cover=45.9312019
-	1:[odor=pungent] yes=4,no=3,gain=10.1308851,cover=43.0564575
+0:[population=clustered] yes=2,no=1,gain=14.8892794,cover=45.9312019
+1:[odor=none] yes=4,no=3,gain=10.1308851,cover=43.0564575
 		3:leaf=0.217203051,cover=22.3283749
 		4:leaf=-0.734555721,cover=20.7280827
-	2:[stalk-surface-above-ring=fibrous] yes=6,no=5,gain=19.3462334,cover=2.87474418
+2:[stalk-root=missing] yes=6,no=5,gain=19.3462334,cover=2.87474418
 		5:leaf=3.63442755,cover=1.34154534
 		6:leaf=-0.609474957,cover=1.53319895
 ");

--- a/src/booster.rs
+++ b/src/booster.rs
@@ -361,6 +361,7 @@ impl Booster {
                                                 dmat.handle,
                                                 option_mask,
                                                 ntree_limit,
+                                                0,
                                                 &mut out_len,
                                                 &mut out_result))?;
 
@@ -381,10 +382,10 @@ impl Booster {
                                                 dmat.handle,
                                                 option_mask,
                                                 ntree_limit,
+                                                1,
                                                 &mut out_len,
                                                 &mut out_result))?;
         assert!(!out_result.is_null());
-
         let data = unsafe { slice::from_raw_parts(out_result, out_len as usize).to_vec() };
         Ok(data)
     }
@@ -403,6 +404,7 @@ impl Booster {
                                                 dmat.handle,
                                                 option_mask,
                                                 ntree_limit,
+                                                0,
                                                 &mut out_len,
                                                 &mut out_result))?;
         assert!(!out_result.is_null());
@@ -429,6 +431,7 @@ impl Booster {
                                                 dmat.handle,
                                                 option_mask,
                                                 ntree_limit,
+                                                0,
                                                 &mut out_len,
                                                 &mut out_result))?;
         assert!(!out_result.is_null());
@@ -456,6 +459,7 @@ impl Booster {
                                                 dmat.handle,
                                                 option_mask,
                                                 ntree_limit,
+                                                0,
                                                 &mut out_len,
                                                 &mut out_result))?;
         assert!(!out_result.is_null());

--- a/src/dmatrix.rs
+++ b/src/dmatrix.rs
@@ -1,6 +1,7 @@
 use std::{slice, ffi, ptr, path::Path};
 use libc::{c_uint, c_float};
 use std::os::unix::ffi::OsStrExt;
+use std::convert::TryInto;
 
 use xgboost_sys;
 
@@ -123,7 +124,7 @@ impl DMatrix {
     /// `data[indptr[i]:indptr[i+1]`.
     ///
     /// If `num_cols` is set to None, number of columns will be inferred from given data.
-    pub fn from_csr(indptr: &[usize], indices: &[usize], data: &[f32], num_cols: Option<usize>) -> XGBResult<Self> {
+    pub fn from_csr(indptr: &[u64], indices: &[usize], data: &[f32], num_cols: Option<usize>) -> XGBResult<Self> {
         assert_eq!(indices.len(), data.len());
         let mut handle = ptr::null_mut();
         let indices: Vec<u32> = indices.iter().map(|x| *x as u32).collect();
@@ -131,9 +132,9 @@ impl DMatrix {
         xgb_call!(xgboost_sys::XGDMatrixCreateFromCSREx(indptr.as_ptr(),
                                                         indices.as_ptr(),
                                                         data.as_ptr(),
-                                                        indptr.len(),
-                                                        data.len(),
-                                                        num_cols,
+                                                        indptr.len().try_into().unwrap(),
+                                                        data.len().try_into().unwrap(),
+                                                        num_cols.try_into().unwrap(),
                                                         &mut handle))?;
         Ok(DMatrix::new(handle)?)
     }
@@ -146,7 +147,7 @@ impl DMatrix {
     /// `data[indptr[i]:indptr[i+1]`.
     ///
     /// If `num_rows` is set to None, number of rows will be inferred from given data.
-    pub fn from_csc(indptr: &[usize], indices: &[usize], data: &[f32], num_rows: Option<usize>) -> XGBResult<Self> {
+    pub fn from_csc(indptr: &[u64], indices: &[usize], data: &[f32], num_rows: Option<usize>) -> XGBResult<Self> {
         assert_eq!(indices.len(), data.len());
         let mut handle = ptr::null_mut();
         let indices: Vec<u32> = indices.iter().map(|x| *x as u32).collect();
@@ -154,9 +155,9 @@ impl DMatrix {
         xgb_call!(xgboost_sys::XGDMatrixCreateFromCSCEx(indptr.as_ptr(),
                                                         indices.as_ptr(),
                                                         data.as_ptr(),
-                                                        indptr.len(),
-                                                        data.len(),
-                                                        num_rows,
+                                                        indptr.len().try_into().unwrap(),
+                                                        data.len().try_into().unwrap(),
+                                                        num_rows.try_into().unwrap(),
                                                         &mut handle))?;
         Ok(DMatrix::new(handle)?)
     }

--- a/src/dmatrix.rs
+++ b/src/dmatrix.rs
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn read_num_cols() {
-        assert_eq!(read_train_matrix().unwrap().num_cols(), 127);
+        assert_eq!(read_train_matrix().unwrap().num_cols(), 126);
     }
 
     #[test]
@@ -466,7 +466,7 @@ mod tests {
         assert_eq!(dmat.slice(&[1]).unwrap().shape(), (1, 2));
         assert_eq!(dmat.slice(&[0, 1]).unwrap().shape(), (2, 2));
         assert_eq!(dmat.slice(&[3, 2, 1]).unwrap().shape(), (3, 2));
-        assert_eq!(dmat.slice(&[10, 11, 12]).unwrap().shape(), (0, 0));
+        assert_eq!(dmat.slice(&[10, 11, 12]).unwrap().shape(), (3, 2));
     }
 
     #[test]

--- a/src/dmatrix.rs
+++ b/src/dmatrix.rs
@@ -124,9 +124,10 @@ impl DMatrix {
     /// `data[indptr[i]:indptr[i+1]`.
     ///
     /// If `num_cols` is set to None, number of columns will be inferred from given data.
-    pub fn from_csr(indptr: &[u64], indices: &[usize], data: &[f32], num_cols: Option<usize>) -> XGBResult<Self> {
+    pub fn from_csr(indptr: &[usize], indices: &[usize], data: &[f32], num_cols: Option<usize>) -> XGBResult<Self> {
         assert_eq!(indices.len(), data.len());
         let mut handle = ptr::null_mut();
+        let indptr: Vec<u64> = indptr.iter().map(|x| *x as u64).collect();
         let indices: Vec<u32> = indices.iter().map(|x| *x as u32).collect();
         let num_cols = num_cols.unwrap_or(0); // infer from data if 0
         xgb_call!(xgboost_sys::XGDMatrixCreateFromCSREx(indptr.as_ptr(),
@@ -147,9 +148,10 @@ impl DMatrix {
     /// `data[indptr[i]:indptr[i+1]`.
     ///
     /// If `num_rows` is set to None, number of rows will be inferred from given data.
-    pub fn from_csc(indptr: &[u64], indices: &[usize], data: &[f32], num_rows: Option<usize>) -> XGBResult<Self> {
+    pub fn from_csc(indptr: &[usize], indices: &[usize], data: &[f32], num_rows: Option<usize>) -> XGBResult<Self> {
         assert_eq!(indices.len(), data.len());
         let mut handle = ptr::null_mut();
+        let indptr: Vec<u64> = indptr.iter().map(|x| *x as u64).collect();
         let indices: Vec<u32> = indices.iter().map(|x| *x as u32).collect();
         let num_rows = num_rows.unwrap_or(0); // infer from data if 0
         xgb_call!(xgboost_sys::XGDMatrixCreateFromCSCEx(indptr.as_ptr(),

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,7 +31,7 @@ impl XGBError {
         match ret_val {
             0  => Ok(()),
             -1 => Err(XGBError::from_xgboost()),
-            _  => panic!(format!("unexpected return value '{}', expected 0 or -1", ret_val)),
+            _  => panic!("unexpected return value '{}', expected 0 or -1", ret_val),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,7 +65,6 @@ extern crate libc;
 extern crate tempfile;
 extern crate indexmap;
 
-#[macro_use]
 macro_rules! xgb_call {
     ($x:expr) => {
         XGBError::check_return_value(unsafe { $x })

--- a/xgboost-sys/Cargo.toml
+++ b/xgboost-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xgboost-sys"
-version = "0.1.2"
+version = "0.2.0"
 authors = ["Dave Challis <dave@suicas.net>"]
 links = "xgboost"
 build = "build.rs"

--- a/xgboost-sys/Cargo.toml
+++ b/xgboost-sys/Cargo.toml
@@ -14,3 +14,4 @@ libc = "0.2"
 
 [build-dependencies]
 bindgen = "0.59"
+cmake = "0.1"

--- a/xgboost-sys/Cargo.toml
+++ b/xgboost-sys/Cargo.toml
@@ -13,4 +13,4 @@ readme = "README.md"
 libc = "0.2"
 
 [build-dependencies]
-bindgen = "0.36"
+bindgen = "0.59"

--- a/xgboost-sys/build.rs
+++ b/xgboost-sys/build.rs
@@ -1,5 +1,7 @@
 extern crate bindgen;
+extern crate cmake;
 
+use cmake::Config;
 use std::process::Command;
 use std::env;
 use std::path::{Path, PathBuf};
@@ -19,23 +21,20 @@ fn main() {
             });
     }
 
-    // TODO: allow for dynamic/static linking
-    // TODO: check whether rabit should be built/linked
-    if !xgb_root.join("lib").exists() {
-        // TODO: better checks for build completion, currently xgboost's build script can run
-        // `make clean_all` if openmp build fails
-        Command::new(xgb_root.join("build.sh"))
-            .current_dir(&xgb_root)
-            .status()
-            .expect("Failed to execute XGBoost build.sh script.");
-    }
+    // CMake
+    let dst = Config::new(&xgb_root)
+        .uses_cxx11()
+        .define("BUILD_STATIC_LIB", "ON")
+        .build();
 
     let xgb_root = xgb_root.canonicalize().unwrap();
 
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
+        .clang_args(&["-x", "c++", "-std=c++11"])
         .clang_arg(format!("-I{}", xgb_root.join("include").display()))
         .clang_arg(format!("-I{}", xgb_root.join("rabit/include").display()))
+        .clang_arg(format!("-I{}", xgb_root.join("dmlc-core/include").display()))
         .generate()
         .expect("Unable to generate bindings.");
 
@@ -48,21 +47,17 @@ fn main() {
     println!("cargo:rustc-link-search={}", xgb_root.join("rabit/lib").display());
     println!("cargo:rustc-link-search={}", xgb_root.join("dmlc-core").display());
 
-    // check if built with multithreading support, otherwise link to dummy lib
-    if xgb_root.join("rabit/lib/librabit.a").exists() {
-        println!("cargo:rustc-link-lib=static=rabit");
-        println!("cargo:rustc-link-lib=dylib=gomp");
-    } else {
-        println!("cargo:rustc-link-lib=static=rabit_empty");
-    }
-
     // link to appropriate C++ lib
     if target.contains("apple") {
         println!("cargo:rustc-link-lib=c++");
+        println!("cargo:rustc-link-lib=dylib=omp");
     } else {
         println!("cargo:rustc-link-lib=stdc++");
+        println!("cargo:rustc-link-lib=dylib=gomp");
     }
 
+    println!("cargo:rustc-link-search=native={}", dst.display());
+    println!("cargo:rustc-link-search=native={}", dst.join("lib").display());
     println!("cargo:rustc-link-lib=static=dmlc");
     println!("cargo:rustc-link-lib=static=xgboost");
 }

--- a/xgboost-sys/wrapper.h
+++ b/xgboost-sys/wrapper.h
@@ -1,1 +1,2 @@
 #include <xgboost/c_api.h>
+#include <rabit/c_api.h>


### PR DESCRIPTION
@davechallis @jonathanstrong Hi. 

# Overview
- fix: https://github.com/davechallis/rust-xgboost/issues/8
    - upgrade xgboost 1.4.2
    - update bindgen
    - update example

# Requires
This PR requires the following merge
- [x] ~https://github.com/davechallis/rust-xgboost/pull/13~
    - Included in this PR
- [ ] https://github.com/davechallis/xgboost/pull/1
- [x] https://github.com/dmlc/xgboost/pull/7265

Confirmed that example/runall.sh is working.

```
$ head xgboost-sys/xgboost/NEWS.md
XGBoost Change Log
==================

This file records the changes in xgboost library in reverse chronological order.

## v1.4.2 (2021.05.13)

$ ./runall.sh
...
Compiling xgboost-sys v0.2.0 (/app/rust-xgboost/xgboost-sys)
...

```

#  Description
- Using CMake because removed `build.sh` https://github.com/dmlc/xgboost/commit/207f0587111a951f5cd6c609ade001587f242bd1
- XGBoosterPredict's args has been changed
    - https://xgboost.readthedocs.io/en/latest/dev/c__api_8h.html#adc14afaedd5f1add105d18942a4de33c
    - 0 for `predict` 
    - 1 for `custom metric training`
- remove `root_index`
    - https://github.com/dmlc/xgboost/pull/5138#discussion_r360838092
- add `group_ptr` 
    - https://github.com/dmlc/xgboost/pull/5187
- demo file to start with 1 index
    - https://github.com/dmlc/xgboost/commit/a894ab6898f5ed525ca7dec89a79ea1fa7f49f5a#diff-b1f466d8b5ac867fc06e6d49115839b7b8428f5c3eb9f7f11488dd677f6f7dbc