### PR TITLE
Change missing from 0 to NaN

### DIFF
--- a/src/dmatrix.rs
+++ b/src/dmatrix.rs
@@ -112,7 +112,7 @@ impl DMatrix {
         xgb_call!(xgboost_sys::XGDMatrixCreateFromMat(data.as_ptr(),
                                                       num_rows as xgboost_sys::bst_ulong,
                                                       (data.len() / num_rows) as xgboost_sys::bst_ulong,
-                                                      0.0, // TODO: can values be missing here?
+                                                      f32::NAN,
                                                       &mut handle))?;
         Ok(DMatrix::new(handle)?)
     }


### PR DESCRIPTION
This branch changes the value of the `missing` argument from 0 to NaN to match the default behavior of the Python front end.
https://github.com/dmlc/xgboost/blob/a197899161fa70e681101de4232745fdfe737804/python-package/xgboost/core.py#L843